### PR TITLE
fix mem() for if the fifth column is missing

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -867,7 +867,10 @@ mem <- function(x, reset = FALSE) {
 		mem <- num_bytes(as.numeric(object.size(x)))
 	} else {
 		cell.size <- c(Ncells=56, Vcells=8)
-		mem <- round(colSums(gc(reset=reset)[,c(1,3,6)] * cell.size) / 1000^2, 1)
+		gc.result <- gc(reset=reset)
+		# There are some cases that the fifth column is missing. See help(gc).
+		max.used.col <- ncol(gc.result) - 1
+		mem <- round(colSums(gc.result[,c(1,3,max.used.col)] * cell.size) / 1000^2, 1)
 		names(mem) <- c("used (MB)", "gc trigger (MB)", "max used (MB)")
 	}
 	mem


### PR DESCRIPTION
About `gc()` results, 
There are some cases that the limit column that is usually at fifth is missing.
So you should specify the second one from the last as the max used column.

For instance, on my macOS, a result of `gc()` has 7 columns:

```
> gc()
          used (Mb) gc trigger (Mb) limit (Mb) max used (Mb)
Ncells  743284 39.7    1245450 66.6         NA  1245450 66.6
Vcells 1771508 13.6    8388608 64.0      16384  2669382 20.4
> ncol(gc())
[1] 7
> sessionInfo()
R version 4.0.3 (2020-10-10)
Platform: x86_64-apple-darwin17.0 (64-bit)
Running under: macOS Catalina 10.15.7
```

On my Windows, it has only 6 columns:

```
> gc()
          used (Mb) gc trigger (Mb) max used (Mb)
Ncells  562643 30.1    1273785 68.1  1273785 68.1
Vcells 1459631 11.2    8388608 64.0  1895012 14.5
> ncol(gc())
[1] 6
> sessionInfo()
R version 4.0.3 (2020-10-10)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 19041)
```

`help(gc)` says:

```
> help(gc)
...
Value
...
If maxima have been set for either "Ncells" or "Vcells", 
a fifth column is printed giving the current limits in Mb (with NA denoting no limit).
...
```
