### PR TITLE
Add backport to unbreak build on R-4.5

### DIFF
--- a/src/altrep.h
+++ b/src/altrep.h
@@ -2,6 +2,10 @@
 #define MATTER_ALTREP
 
 #include <R_ext/Altrep.h>
+#include <Rversion.h>
+#if R_VERSION < R_Version(4, 6, 0)
+#define DATAPTR_RW(x) DATAPTR(x)
+#endif
 
 #define MATTER_PKG "matter"
 


### PR DESCRIPTION
I know this package is intended for bioc-devel/r-devel, but several components of R-universe run r-release to render things, so it would be nice if we can keep supporting that version too for now.

See https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Some-backports

@kuwisdelu this complements your commit https://github.com/kuwisdelu/matter/commit/c2629bdf45d7752629bd9079cdc59be4e27e4ed6